### PR TITLE
Fixed WARNING: Title underline too short

### DIFF
--- a/Introduction/asynchronous-example.rst
+++ b/Introduction/asynchronous-example.rst
@@ -40,7 +40,7 @@ Register the bundles in Symfony's AppKernel.php
     }
 
 Configuration
------------
+-------------
 
 There is quite a lot of moving parts in this configuration. Most if it is to configure
 the queue and make sure RabbitMqBundle is aware of SimpleBus' consumers and producers.


### PR DESCRIPTION
This commit fixes the warning: Title underline too short.